### PR TITLE
Update runtime to 40

### DIFF
--- a/org.gnome.Podcasts.json
+++ b/org.gnome.Podcasts.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "org.gnome.Podcasts",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "40",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
The GNOME 3.38 runtime is no longer supported as of August 19, 2021.