### PR TITLE
Added DRI access

### DIFF
--- a/org.gnome.Podcasts.json
+++ b/org.gnome.Podcasts.json
@@ -35,6 +35,10 @@
                     "type" : "archive",
                     "url" : "https://gitlab.gnome.org/World/podcasts/uploads/7f5cb601b1eea22cc473077e8c0dcfad/gnome-podcasts-0.6.1.tar.xz",
                     "sha256" : "3e8df13c8eaf49f28e66ad3628b18c5893dc864c1f3579693e287263bc871539"
+                },
+                {
+                    "type": "patch",
+                    "path": "podcasts-appdata.patch"
                 }
             ]
         }

--- a/org.gnome.Podcasts.json
+++ b/org.gnome.Podcasts.json
@@ -10,6 +10,7 @@
     "finish-args" : [
         "--metadata=X-DConf=migrate-path=/org/gnome/Podcasts/",
         "--share=network",
+        "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",

--- a/podcasts-appdata.patch
+++ b/podcasts-appdata.patch
@@ -1,0 +1,39 @@
+diff --git a/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in b/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in
+index cd008640..0329fbe4 100644
+--- a/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in
++++ b/podcasts-gtk/resources/org.gnome.Podcasts.appdata.xml.in.in
+@@ -15,13 +15,13 @@
+   </description>
+   <screenshots>
+     <screenshot type="default">
+-      <image>https://gitlab.gnome.org/World/podcasts/raw/master/screenshots/home_view.png</image>
++      <image>https://gitlab.gnome.org/World/podcasts/raw/0.6.1/screenshots/home_view.png</image>
+     </screenshot>
+     <screenshot>
+-      <image>https://gitlab.gnome.org/World/podcasts/raw/master/screenshots/shows_view.png</image>
++      <image>https://gitlab.gnome.org/World/podcasts/raw/0.6.1/screenshots/shows_view.png</image>
+     </screenshot>
+     <screenshot>
+-      <image>https://gitlab.gnome.org/World/podcasts/raw/master/screenshots/show_widget.png</image>
++      <image>https://gitlab.gnome.org/World/podcasts/raw/0.6.1/screenshots/show_widget.png</image>
+     </screenshot>
+   </screenshots>
+   <releases>
+@@ -136,7 +136,7 @@
+     <control>touch</control>
+   </recommends>
+   <requires>
+-    <display_length compare="ge">small</display_length>
++    <display_length compare="ge">768</display_length>
+   </requires>
+   <launchable type="desktop-id">@appid@.desktop</launchable>
+   <url type="homepage">https://apps.gnome.org/app/org.gnome.Podcasts/</url>
+@@ -149,8 +149,6 @@
+   <update_contact>jpetridis@gnome.org</update_contact>
+   <developer_name>The Podcasts developers</developer_name>
+   <custom>
+-    <value key="Purism::form_factor">workstation</value>
+-    <value key="Purism::form_factor">mobile</value>
+     <value key="GnomeSoftware::key-colors">[(250, 181, 174)]</value>
+   </custom>
+ </component>


### PR DESCRIPTION
This should solve
```
libEGL warning: wayland-egl: could not open /dev/dri/renderD128 (No such file or directory)
MESA: error: ZINK: failed to choose pdev
libEGL warning: egl: failed to create dri2 screen
```