### PR TITLE
Update flatpak runtime to Gnome 48

### DIFF
--- a/org.gnome.Podcasts.json
+++ b/org.gnome.Podcasts.json
@@ -1,7 +1,7 @@
 {
     "id" : "org.gnome.Podcasts",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "47",
+    "runtime-version" : "48",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions" : [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
First attempt trying this. I simply forked your current project, added the new flatpak Gnome 48 runtime and deleted Gnome 47 runtime. I believe I've done a pull request correctly, but as this is my first time trying this I may or may not have made any mistakes. Please let me know if this works good thank you. 